### PR TITLE
支持`think-orm`缓存

### DIFF
--- a/src/ThinkCache.php
+++ b/src/ThinkCache.php
@@ -5,6 +5,8 @@ namespace Webman\ThinkCache;
 use Webman\Bootstrap;
 use Workerman\Timer;
 use think\facade\Cache;
+use think\Container;
+use think\DbManager;
 
 class ThinkCache implements Bootstrap
 {
@@ -19,6 +21,11 @@ class ThinkCache implements Bootstrap
             Timer::add(55, function () {
                 Cache::get('ping');
             });
+        }
+
+        if (class_exists(DbManager::class)) {
+            $manager_instance = Container::getInstance()->make(DbManager::class);
+            $manager_instance->setCache(Cache::store());
         }
     }
 }


### PR DESCRIPTION
单独安装的`think-orm`默认没有缓存驱动，查询时使用`cache()`方法无效。
如果同时安装了`think-orm`和`think-cache`，使用它作为`think-orm`的缓存驱动。